### PR TITLE
remove test index filter and enable metadata nesting

### DIFF
--- a/roles/apm_agent/files/conf/filters.conf
+++ b/roles/apm_agent/files/conf/filters.conf
@@ -71,23 +71,10 @@
     Nested_under  labels
     Remove_prefix labels_
 
-# User these filters to load to a test index
-# [FILTER]
-#     Name modify
-#     Match *
-#     Add @metadata.index nrm-andreas-test<%=YYYY.MM=%>
-#     Add @metadata.hash host.hostname,log.file.name,offset,message
-#     Add @metadata.docId log.file.name,offset,event.hash
-#     Add @metadata.timestampField apache.access.time
-#     Add @metadata.timestampFormat DD/MMM/YYYY:HH:mm:ss
-#     Add @metadata.apacheAccessLog true
-#     Add @metadata.httpStatusOutcome true
-#     Add @metadata.fileAttributes true
-
-# [FILTER]
-#     Name nest
-#     Match *
-#     Operation nest
-#     Wildcard @metadata.*
-#     Nest_under @metadata
-#     Remove_prefix @metadata.
+[FILTER]
+    Name nest
+    Match *
+    Operation nest
+    Wildcard @metadata.*
+    Nest_under @metadata
+    Remove_prefix @metadata.


### PR DESCRIPTION
For situations where using a test index is needed, I thought it best to move this config to the app's config so matching could be more precise. I also enabled the filter to nest metadata as this should not have been commented out in the first place. 