### PR TITLE
add separate log db dir

### DIFF
--- a/roles/apm_app_collector/tasks/main.yml
+++ b/roles/apm_app_collector/tasks/main.yml
@@ -39,6 +39,7 @@
     - '{{ apm_agent_home }}/conf/{{ app | lower }}-{{ component | lower }}/filter'
     - '{{ apm_agent_home }}/conf/{{ app | lower }}-{{ component | lower }}/input'
     - '{{ apm_agent_home }}/conf/{{ app | lower }}-{{ component | lower }}/parser'
+    - '{{ apm_agent_home }}/db/fluent-bit-logs-{{ app | lower }}-{{ component | lower }}'
   become: yes
   become_user: wwwadm
 


### PR DESCRIPTION
Adding a separate directory for each app's log db files. By keeping them separate, they should be easier to manage.