### PR TITLE
fix: host metric fields

### DIFF
--- a/roles/apm_agent/files/conf/filters.lua
+++ b/roles/apm_agent/files/conf/filters.lua
@@ -181,9 +181,15 @@ function modify_cpu_stats(tag, timestamp, record)
     core_max = nil
     core_average = nil
     core_stddev = nil
+    core_json = "["
     while(not(isempty(new_record[string.format("cpu%d.p_cpu", core)])) and not(isempty(new_record[string.format("cpu%d.p_user", core)])) and not(isempty(new_record[string.format("cpu%d.p_system", core)])) )
     do
         core_cpu[core] = new_record[string.format("cpu%d.p_cpu", core)]
+
+        core_json = core_json .. string.format('{"usage":%f,"user":%f,"system":%f},',
+            new_record[string.format("cpu%d.p_cpu", core)],
+            new_record[string.format("cpu%d.p_user", core)],
+            new_record[string.format("cpu%d.p_system", core)])
 
         new_record[string.format("cpu%d.p_cpu", core)] = nil
         new_record[string.format("cpu%d.p_user", core)] = nil
@@ -191,7 +197,9 @@ function modify_cpu_stats(tag, timestamp, record)
         core = core + 1
     end
     if core > 0 then
+        core_json = core_json:sub(1, -2) .. "]"
         new_record["host.cpu.cores"] = core
+        new_record["host.cpu.core_json"] = core_json
         new_record["host.cpu.core_mean"] = stats.mean(core_cpu)
         new_record["host.cpu.core_median"] = stats.median(core_cpu)
         new_record["host.cpu.core_min"], new_record["host.cpu.core_max"] = stats.maxmin(core_cpu)

--- a/roles/apm_agent/files/conf/filters.lua
+++ b/roles/apm_agent/files/conf/filters.lua
@@ -186,8 +186,7 @@ function modify_cpu_stats(tag, timestamp, record)
     do
         core_cpu[core] = new_record[string.format("cpu%d.p_cpu", core)]
 
-        core_json = core_json .. string.format('{"usage":%f,"user":%f,"system":%f},',
-            new_record[string.format("cpu%d.p_cpu", core)],
+        core_json = core_json .. string.format('{"user":%f,"system":%f},',
             new_record[string.format("cpu%d.p_user", core)],
             new_record[string.format("cpu%d.p_system", core)])
 
@@ -200,10 +199,9 @@ function modify_cpu_stats(tag, timestamp, record)
         core_json = core_json:sub(1, -2) .. "]"
         new_record["host.cpu.cores"] = core
         new_record["host.cpu.core_json"] = core_json
-        new_record["host.cpu.core_mean"] = stats.mean(core_cpu)
-        new_record["host.cpu.core_median"] = stats.median(core_cpu)
-        new_record["host.cpu.core_min"], new_record["host.cpu.core_max"] = stats.maxmin(core_cpu)
-        new_record["host.cpu.core_stddev"], new_record["host.cpu.core_max"] = stats.standardDeviation(core_cpu)
+        new_record["host.cpu.usage_core_median"] = stats.median(core_cpu)
+        new_record["host.cpu.usage_core_max"], new_record["host.cpu.usage_core_min"] = stats.maxmin(core_cpu)
+        new_record["host.cpu.usage_core_stddev"] = stats.standardDeviation(core_cpu)
     end
     return 2, timestamp, new_record
 end

--- a/roles/apm_agent/files/conf/filters.lua
+++ b/roles/apm_agent/files/conf/filters.lua
@@ -73,11 +73,11 @@ end
 
 function add_system_memory_percentage(tag, timestamp, record)
     new_record = record
-    if not(isempty(new_record["system.memory.used.bytes"])) and not(isempty(new_record["system.memory.total"])) then
-        new_record["system.memory.used.pct"] = record["system.memory.used.bytes"] / record["system.memory.total"]
+    if not(isempty(new_record["host.memory.used"])) and not(isempty(new_record["host.memory.total"])) then
+        new_record["host.memory.used_percentage"] = record["host.memory.used"] / record["host.memory.total"]
     end
-    if not(isempty(new_record["system.memory.swap.used.bytes"])) and not(isempty(new_record["system.memory.swap.total"])) then
-        new_record["system.memory.swap.used.pct"] = record["system.memory.swap.used.bytes"] / record["system.memory.swap.total"]
+    if not(isempty(new_record["host.swap.used"])) and not(isempty(new_record["host.swap.total"])) then
+        new_record["host.swap.used_percentage"] = record["system.memory.swap.used.bytes"] / record["host.swap.total"]
     end
     return 2, timestamp, new_record
 end

--- a/roles/apm_agent/files/conf/filters.lua
+++ b/roles/apm_agent/files/conf/filters.lua
@@ -16,6 +16,97 @@ function remove_nil_fields(tag, timestamp, record)
     return 2, timestamp, record
 end
 
+
+-- Small stats library                      --
+----------------------------------------------
+-- Version History --
+-- 1.0 First written.
+
+-- Tables supplied as arguments are not changed.
+-- Credit: http://lua-users.org/wiki/SimpleStats
+
+-- Table to hold statistical functions
+stats={}
+
+-- Get the mean value of a table
+function stats.mean( t )
+  local sum = 0
+  local count= 0
+
+  for k,v in pairs(t) do
+    if type(v) == 'number' then
+      sum = sum + v
+      count = count + 1
+    end
+  end
+
+  return (sum / count)
+end
+
+-- Get the median of a table.
+function stats.median( t )
+  local temp={}
+
+  -- deep copy table so that when we sort it, the original is unchanged
+  -- also weed out any non numbers
+  for k,v in pairs(t) do
+    if type(v) == 'number' then
+      table.insert( temp, v )
+    end
+  end
+
+  table.sort( temp )
+
+  -- If we have an even number of table elements or odd.
+  if math.fmod(#temp,2) == 0 then
+    -- return mean value of middle two elements
+    return ( temp[#temp/2] + temp[(#temp/2)+1] ) / 2
+  else
+    -- return middle element
+    return temp[math.ceil(#temp/2)]
+  end
+end
+
+
+-- Get the standard deviation of a table
+function stats.standardDeviation( t )
+  local m
+  local vm
+  local sum = 0
+  local count = 0
+  local result
+
+  m = stats.mean( t )
+
+  for k,v in pairs(t) do
+    if type(v) == 'number' then
+      vm = v - m
+      sum = sum + (vm * vm)
+      count = count + 1
+    end
+  end
+
+  result = math.sqrt(sum / (count-1))
+
+  return result
+end
+
+-- Get the max and min for a table
+function stats.maxmin( t )
+  local max = -math.huge
+  local min = math.huge
+
+  for k,v in pairs( t ) do
+    if type(v) == 'number' then
+      max = math.max( max, v )
+      min = math.min( min, v )
+    end
+  end
+
+  return max, min
+end
+-- End: Small stats library                      --
+
 function append_event_created(tag, timestamp, record)
     new_record = record
     new_record["event.created"] = (os.date("!%Y-%m-%dT%H:%M:%S", timestamp["sec"]) .. '.' .. math.floor(timestamp["nsec"] / 1000000) .. 'Z')
@@ -78,6 +169,32 @@ function add_system_memory_percentage(tag, timestamp, record)
     end
     if not(isempty(new_record["host.swap.used"])) and not(isempty(new_record["host.swap.total"])) then
         new_record["host.swap.used_percentage"] = record["system.memory.swap.used.bytes"] / record["host.swap.total"]
+    end
+    return 2, timestamp, new_record
+end
+
+function modify_cpu_stats(tag, timestamp, record)
+    new_record = record
+    core = 0
+    core_cpu = {}
+    core_min = nil
+    core_max = nil
+    core_average = nil
+    core_stddev = nil
+    while(not(isempty(new_record[string.format("cpu%d.p_cpu", core)])) and not(isempty(new_record[string.format("cpu%d.p_user", core)])) and not(isempty(new_record[string.format("cpu%d.p_system", core)])) )
+    do
+        core_cpu[core] = new_record[string.format("cpu%d.p_cpu", core)]
+
+        new_record[string.format("cpu%d.p_cpu", core)] = nil
+        new_record[string.format("cpu%d.p_user", core)] = nil
+        new_record[string.format("cpu%d.p_system", core)] = nil
+        core = core + 1
+    end
+    if core > 0 then
+        new_record["host.cpu.core_mean"] = stats.mean(core_cpu)
+        new_record["host.cpu.core_median"] = stats.median(core_cpu)
+        new_record["host.cpu.core_min"], new_record["host.cpu.core_max"] = stats.maxmin(core_cpu)
+        new_record["host.cpu.core_stddev"], new_record["host.cpu.core_max"] = stats.standardDeviation(core_cpu)
     end
     return 2, timestamp, new_record
 end

--- a/roles/apm_agent/files/conf/filters.lua
+++ b/roles/apm_agent/files/conf/filters.lua
@@ -191,6 +191,7 @@ function modify_cpu_stats(tag, timestamp, record)
         core = core + 1
     end
     if core > 0 then
+        new_record["host.cpu.cores"] = core
         new_record["host.cpu.core_mean"] = stats.mean(core_cpu)
         new_record["host.cpu.core_median"] = stats.median(core_cpu)
         new_record["host.cpu.core_min"], new_record["host.cpu.core_max"] = stats.maxmin(core_cpu)

--- a/roles/apm_agent/files/conf/filters.lua
+++ b/roles/apm_agent/files/conf/filters.lua
@@ -168,7 +168,7 @@ function add_system_memory_percentage(tag, timestamp, record)
         new_record["host.memory.used_percentage"] = record["host.memory.used"] / record["host.memory.total"]
     end
     if not(isempty(new_record["host.swap.used"])) and not(isempty(new_record["host.swap.total"])) then
-        new_record["host.swap.used_percentage"] = record["system.memory.swap.used.bytes"] / record["host.swap.total"]
+        new_record["host.swap.used_percentage"] = record["host.swap.used"] / record["host.swap.total"]
     end
     return 2, timestamp, new_record
 end

--- a/roles/apm_metrics_collector/files/conf/metrics/filter/filters.conf
+++ b/roles/apm_metrics_collector/files/conf/metrics/filter/filters.conf
@@ -1,6 +1,6 @@
 [FILTER]
     Name modify
-    Match metrics.system.cpu
+    Match metrics.host.cpu
     Add event.kind metric
     Add event.category system
     Add event.dataset host.cpu
@@ -11,7 +11,7 @@
 
 [FILTER]
     Name modify
-    Match metrics.system.memory
+    Match metrics.host.memory
     Add event.kind metric
     Add event.category system
     Add event.dataset host.memory
@@ -32,14 +32,14 @@
 
 [FILTER]
     Name lua
-    Match metrics.system.memory
+    Match metrics.host.memory
     script ${FLUENT_HOME}/conf/filters.lua
     time_as_table True
     call add_system_memory_percentage
 
 [FILTER]
     Name lua
-    Match metrics.system.memory
+    Match metrics.host.memory
     script ${FLUENT_HOME}/conf/filters.lua
     time_as_table True
     call modify_cpu_stats

--- a/roles/apm_metrics_collector/files/conf/metrics/filter/filters.conf
+++ b/roles/apm_metrics_collector/files/conf/metrics/filter/filters.conf
@@ -3,10 +3,10 @@
     Match metrics.system.cpu
     Add event.kind metric
     Add event.category system
-    Add event.dataset system.cpu
-    Rename user_p system.cpu.user.pct
-    Rename system_p system.cpu.system.pct
-    Rename cpu_p system.cpu.total.pct
+    Add event.dataset host.cpu
+    Rename user_p host.cpu.user
+    Rename system_p host.cpu.system
+    Rename cpu_p host.cpu.usage
     Add @metadata.keyAsPath true
 
 [FILTER]
@@ -14,13 +14,13 @@
     Match metrics.system.memory
     Add event.kind metric
     Add event.category system
-    Add event.dataset system.memory
-    Rename Mem.total system.memory.total
-    Rename Mem.used system.memory.used.bytes
-    Rename Mem.free system.memory.free
-    Rename Swap.total system.memory.swap.total
-    Rename Swap.used system.memory.swap.used.bytes
-    Rename Swap.free system.memory.swap.free
+    Add event.dataset host.memory
+    Rename Mem.total host.memory.total
+    Rename Mem.used host.memory.used
+    Rename Mem.free host.memory.free
+    Rename Swap.total host.swap.total
+    Rename Swap.used host.swap.used
+    Rename Swap.free host.swap.free
     Add @metadata.keyAsPath true
 
 [FILTER]

--- a/roles/apm_metrics_collector/files/conf/metrics/filter/filters.conf
+++ b/roles/apm_metrics_collector/files/conf/metrics/filter/filters.conf
@@ -2,7 +2,7 @@
     Name modify
     Match metrics.host.cpu
     Add event.kind metric
-    Add event.category system
+    Add event.category host
     Add event.dataset host.cpu
     Rename cpu_p host.cpu.usage
     Rename user_p host.cpu.user
@@ -13,7 +13,7 @@
     Name modify
     Match metrics.host.memory
     Add event.kind metric
-    Add event.category system
+    Add event.category host
     Add event.dataset host.memory
     Rename Mem.total host.memory.total
     Rename Mem.used host.memory.used
@@ -39,7 +39,7 @@
 
 [FILTER]
     Name lua
-    Match metrics.host.memory
+    Match metrics.host.cpu
     script ${FLUENT_HOME}/conf/filters.lua
     time_as_table True
     call modify_cpu_stats

--- a/roles/apm_metrics_collector/files/conf/metrics/filter/filters.conf
+++ b/roles/apm_metrics_collector/files/conf/metrics/filter/filters.conf
@@ -4,9 +4,9 @@
     Add event.kind metric
     Add event.category system
     Add event.dataset host.cpu
+    Rename cpu_p host.cpu.usage
     Rename user_p host.cpu.user
     Rename system_p host.cpu.system
-    Rename cpu_p host.cpu.usage
     Add @metadata.keyAsPath true
 
 [FILTER]
@@ -36,3 +36,10 @@
     script ${FLUENT_HOME}/conf/filters.lua
     time_as_table True
     call add_system_memory_percentage
+
+[FILTER]
+    Name lua
+    Match metrics.system.memory
+    script ${FLUENT_HOME}/conf/filters.lua
+    time_as_table True
+    call modify_cpu_stats

--- a/roles/apm_metrics_collector/files/conf/metrics/input/inputs.conf
+++ b/roles/apm_metrics_collector/files/conf/metrics/input/inputs.conf
@@ -1,9 +1,9 @@
 [INPUT]
     Name cpu
-    Tag  metrics.system.cpu
+    Tag  metrics.host.cpu
     Interval_Sec 30
-    
+
 [INPUT]
     Name mem
-    Tag  metrics.system.memory
+    Tag  metrics.host.memory
     Interval_Sec 30


### PR DESCRIPTION
Quote: ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.

Moving metrics to correct place