### PR TITLE
added match regex to exclude metrics

### DIFF
--- a/roles/apm_agent/files/conf/filters.conf
+++ b/roles/apm_agent/files/conf/filters.conf
@@ -8,7 +8,7 @@
 
 [FILTER]
     Name lua
-    Match *
+    Match_Regex ^(?!metrics).*
     script ${FLUENT_HOME}/conf/filters.lua
     time_as_table True
     call append_event_created


### PR DESCRIPTION
Metrics should never send an 'event.created' field, so I've added a regex match to exclude metrics tags from the lua filter call to append_event_created.