### PR TITLE
Add ecs version

### DIFF
--- a/roles/apm_agent/files/conf/filters.conf
+++ b/roles/apm_agent/files/conf/filters.conf
@@ -3,6 +3,7 @@
     Match *
     Add agent.type fluentbit
     Add agent.version ${FLUENT_VERSION}
+    Add ecs.version 1.12.1
     Rename level log.level
     Copy message event.original
 
@@ -63,3 +64,12 @@
     Wildcard event.*
     Nest_under event
     Remove_prefix event.
+
+# nest ecs version
+[FILTER]
+        Name nest
+        Match *
+        Operation nest
+        Wildcard ecs.*
+        Nest_under ecs
+        Remove_prefix ecs.

--- a/roles/apm_agent/files/conf/filters.conf
+++ b/roles/apm_agent/files/conf/filters.conf
@@ -67,9 +67,9 @@
 
 # nest ecs version
 [FILTER]
-        Name nest
-        Match *
-        Operation nest
-        Wildcard ecs.*
-        Nest_under ecs
-        Remove_prefix ecs.
+    Name nest
+    Match *
+    Operation nest
+    Wildcard ecs.*
+    Nest_under ecs
+    Remove_prefix ecs.

--- a/roles/apm_agent/files/conf/filters.conf
+++ b/roles/apm_agent/files/conf/filters.conf
@@ -8,7 +8,7 @@
 
 [FILTER]
     Name lua
-    Match *
+    Match_Regex ^(?!metrics).*
     script ${FLUENT_HOME}/conf/filters.lua
     time_as_table True
     call append_event_created

--- a/roles/apm_agent/files/conf/filters.conf
+++ b/roles/apm_agent/files/conf/filters.conf
@@ -3,7 +3,7 @@
     Match *
     Add agent.type fluentbit
     Add agent.version ${FLUENT_VERSION}
-    Add ecs.version 1.12.1
+    Add ecs.version 1.12.0
     Rename level log.level
     Copy message event.original
 


### PR DESCRIPTION
We should start sending the ecs version with all events. I've added the ecs version of 1.12.0 to the base filter configuration.