### PR TITLE
Hotfix/lb legacy db fix

### DIFF
--- a/roles/liquibase/files/nrdk/nrdk.xml
+++ b/roles/liquibase/files/nrdk/nrdk.xml
@@ -35,7 +35,7 @@
 
     <changeSet  author="qed"  id="iitd_support_pkg_body" runAlways="true" runOnChange="true" failOnError="false" context="setup">
         <preConditions onFail="WARN" onError="HALT" onFailMessage="Oracle version is 11 or earlier. Using legacy package body">
-            <sqlCheck expectedResult="STANDARD">select decode(regexp_replace(version,'\..*',''),'11','LEGACY','STANDARD') from v$instance</sqlCheck>
+            <sqlCheck expectedResult="STANDARD">select min(decode(regexp_replace(regexp_replace(banner,'\..*',''),'.* ','')),'11','LEGACY','STANDARD') from v$version</sqlCheck>
         </preConditions>
         <sqlFile  dbms="oracle"
                   encoding="UTF-8"
@@ -48,7 +48,7 @@
 
     <changeSet  author="qed"  id="iitd_legacy_support_pkg_body" runAlways="true" runOnChange="true" failOnError="false" context="setup">
         <preConditions onFail="CONTINUE" onError="HALT">
-            <sqlCheck expectedResult="LEGACY">select decode(regexp_replace(version,'\..*',''),'11','LEGACY','STANDARD') from v$instance</sqlCheck>
+            <sqlCheck expectedResult="LEGACY">select min(decode(regexp_replace(regexp_replace(banner,'\..*',''),'.* ','')),'11','LEGACY','STANDARD') from v$version</sqlCheck>
         </preConditions>
         <sqlFile  dbms="oracle"
                   encoding="UTF-8"

--- a/roles/liquibase/files/nrdk/nrdk.xml
+++ b/roles/liquibase/files/nrdk/nrdk.xml
@@ -35,7 +35,7 @@
 
     <changeSet  author="qed"  id="iitd_support_pkg_body" runAlways="true" runOnChange="true" failOnError="false" context="setup">
         <preConditions onFail="WARN" onError="HALT" onFailMessage="Oracle version is 11 or earlier. Using legacy package body">
-            <sqlCheck expectedResult="STANDARD">select min(decode(regexp_replace(regexp_replace(banner,'\..*',''),'.* ','')),'11','LEGACY','STANDARD') from v$version</sqlCheck>
+            <sqlCheck expectedResult="STANDARD">select decode(min(regexp_replace(regexp_replace(banner,'\..*',''),'.* ','')),'11','LEGACY','STANDARD') from v$version</sqlCheck>
         </preConditions>
         <sqlFile  dbms="oracle"
                   encoding="UTF-8"
@@ -48,7 +48,7 @@
 
     <changeSet  author="qed"  id="iitd_legacy_support_pkg_body" runAlways="true" runOnChange="true" failOnError="false" context="setup">
         <preConditions onFail="CONTINUE" onError="HALT">
-            <sqlCheck expectedResult="LEGACY">select min(decode(regexp_replace(regexp_replace(banner,'\..*',''),'.* ','')),'11','LEGACY','STANDARD') from v$version</sqlCheck>
+            <sqlCheck expectedResult="LEGACY">select decode(min(regexp_replace(regexp_replace(banner,'\..*',''),'.* ','')),'11','LEGACY','STANDARD') from v$version</sqlCheck>
         </preConditions>
         <sqlFile  dbms="oracle"
                   encoding="UTF-8"

--- a/roles/liquibase/files/nrdk/sql/v2021.11.01.1755.1__create_iitd_lb_support_pkg_body.sql
+++ b/roles/liquibase/files/nrdk/sql/v2021.11.01.1755.1__create_iitd_lb_support_pkg_body.sql
@@ -1,7 +1,7 @@
 --liquibase formatted sql
 --changeset qed:iitd_support_pkg_body splitStatements:true endDelimiter:/
 --preconditions onFail:WARN onError:HALT onFailMessage:"Running against Oracle RDBMS <= 11"
---precondition-sql-check expectedResult:STANDARD select decode(regexp_replace(version,'\..*',''),'11','LEGACY','STANDARD') from v$instance/
+--precondition-sql-check expectedResult:STANDARD select min(decode(regexp_replace(regexp_replace(banner,'\..*',''),'.* ','')),'11','LEGACY','STANDARD') from v$version/
 create or replace package body iitd_lb_support_pkg as
     -- STANDARD version
     FUNCTION CSV_TO_TABLE(str varchar2) return VARCHAR2_TABLE PIPELINED is

--- a/roles/liquibase/files/nrdk/sql/v2021.11.01.1755.1__create_iitd_lb_support_pkg_body.sql
+++ b/roles/liquibase/files/nrdk/sql/v2021.11.01.1755.1__create_iitd_lb_support_pkg_body.sql
@@ -1,7 +1,7 @@
 --liquibase formatted sql
 --changeset qed:iitd_support_pkg_body splitStatements:true endDelimiter:/
 --preconditions onFail:WARN onError:HALT onFailMessage:"Running against Oracle RDBMS <= 11"
---precondition-sql-check expectedResult:STANDARD select min(decode(regexp_replace(regexp_replace(banner,'\..*',''),'.* ','')),'11','LEGACY','STANDARD') from v$version/
+--precondition-sql-check expectedResult:STANDARD select decode(min(regexp_replace(regexp_replace(banner,'\..*',''),'.* ','')),'11','LEGACY','STANDARD') from v$version/
 create or replace package body iitd_lb_support_pkg as
     -- STANDARD version
     FUNCTION CSV_TO_TABLE(str varchar2) return VARCHAR2_TABLE PIPELINED is

--- a/roles/liquibase/files/nrdk/sql/v2021.11.01.1755.1__create_iitd_legacy_lb_support_pkg_body.sql
+++ b/roles/liquibase/files/nrdk/sql/v2021.11.01.1755.1__create_iitd_legacy_lb_support_pkg_body.sql
@@ -1,7 +1,7 @@
 --liquibase formatted sql
 --changeset qed:iitd_legacy_support_pkg_body splitStatements:true endDelimiter:/
 --preconditions onFail:CONTINUE onError:HALT
---precondition-sql-check expectedResult:LEGACY select min(decode(regexp_replace(regexp_replace(banner,'\..*',''),'.* ','')),'11','LEGACY','STANDARD') from v$version/
+--precondition-sql-check expectedResult:LEGACY select decode(min(regexp_replace(regexp_replace(banner,'\..*',''),'.* ','')),'11','LEGACY','STANDARD') from v$version/
 create or replace package body iitd_lb_support_pkg as
     -- LEGACY version
     FUNCTION CSV_TO_TABLE(str varchar2) return VARCHAR2_TABLE PIPELINED is

--- a/roles/liquibase/files/nrdk/sql/v2021.11.01.1755.1__create_iitd_legacy_lb_support_pkg_body.sql
+++ b/roles/liquibase/files/nrdk/sql/v2021.11.01.1755.1__create_iitd_legacy_lb_support_pkg_body.sql
@@ -1,7 +1,7 @@
 --liquibase formatted sql
 --changeset qed:iitd_legacy_support_pkg_body splitStatements:true endDelimiter:/
 --preconditions onFail:CONTINUE onError:HALT
---precondition-sql-check expectedResult:LEGACY select decode(regexp_replace(version,'\..*',''),'11','LEGACY','STANDARD') from v$instance/
+--precondition-sql-check expectedResult:LEGACY select min(decode(regexp_replace(regexp_replace(banner,'\..*',''),'.* ','')),'11','LEGACY','STANDARD') from v$version/
 create or replace package body iitd_lb_support_pkg as
     -- LEGACY version
     FUNCTION CSV_TO_TABLE(str varchar2) return VARCHAR2_TABLE PIPELINED is


### PR DESCRIPTION
This fixes the precondition which determines which version of the IITD_LB_SUPPORT_PKG is used based on the Oracle RDMBS version.