### PR TITLE
Feature/dont fail restore source

### DIFF
--- a/roles/liquibase/files/nrdk/nrdk.xml
+++ b/roles/liquibase/files/nrdk/nrdk.xml
@@ -30,7 +30,7 @@
                   endDelimiter="/"
                   path="sql/v2021.11.01.1754.1__create_iitd_lb_support_pkg.sql"
                   relativeToChangelogFile="true"
-                  stripComments="true"/>
+                  stripComments="false"/>
     </changeSet>
 
     <changeSet  author="qed"  id="iitd_support_pkg_body" runAlways="true" runOnChange="true" failOnError="false" context="setup">
@@ -43,7 +43,7 @@
                   endDelimiter="/"
                   path="sql/v2021.11.01.1755.1__create_iitd_lb_support_pkg_body.sql"
                   relativeToChangelogFile="true"
-                  stripComments="true"/>
+                  stripComments="false"/>
     </changeSet>
 
     <changeSet  author="qed"  id="iitd_legacy_support_pkg_body" runAlways="true" runOnChange="true" failOnError="false" context="setup">
@@ -56,7 +56,7 @@
                   endDelimiter="/"
                   path="sql/v2021.11.01.1755.1__create_iitd_legacy_lb_support_pkg_body.sql"
                   relativeToChangelogFile="true"
-                  stripComments="true"/>
+                  stripComments="false"/>
     </changeSet>
 
     <changeSet  author="qed"  id="log_schema_state_${stage}" runAlways="true" runOnChange="true" failOnError="true" context="log_schema_state" dbms="oracle">

--- a/roles/liquibase/files/nrdk/sql/v2021.11.01.1754.1__create_iitd_lb_support_pkg.sql
+++ b/roles/liquibase/files/nrdk/sql/v2021.11.01.1754.1__create_iitd_lb_support_pkg.sql
@@ -1,5 +1,5 @@
 --liquibase formatted sql
---changeset qed:iitd_support_pkg splitStatements:true endDelimiter:/
+--changeset qed:iitd_support_pkg stripComments:false splitStatements:true endDelimiter:/
 create or replace package iitd_lb_support_pkg as
     e_uncompiled_objects EXCEPTION;
     PRAGMA exception_init (e_uncompiled_objects, -20001);

--- a/roles/liquibase/files/nrdk/sql/v2021.11.01.1755.1__create_iitd_lb_support_pkg_body.sql
+++ b/roles/liquibase/files/nrdk/sql/v2021.11.01.1755.1__create_iitd_lb_support_pkg_body.sql
@@ -171,10 +171,12 @@ create or replace package body iitd_lb_support_pkg as
         execute immediate 'create or replace ' || source_to_restore.text;
     EXCEPTION
         when OTHERS then
+            -- Catch Success with Compilation Error and ignore. When rolling back PL/SQL packages, the body is reverted
+            -- first and if is paired with a Spec change it will fail until the Spec is rolled back too. The recompile
+            -- happens after the rollback.
             if SQLCODE <> -24344 then
                raise;
             end if;
-        null;
     end;
 
     -- Functions to generate and clear schema state data

--- a/roles/liquibase/files/nrdk/sql/v2021.11.01.1755.1__create_iitd_lb_support_pkg_body.sql
+++ b/roles/liquibase/files/nrdk/sql/v2021.11.01.1755.1__create_iitd_lb_support_pkg_body.sql
@@ -169,6 +169,12 @@ create or replace package body iitd_lb_support_pkg as
           and source_name = p_source_name
           and source_version = p_version_number;
         execute immediate 'create or replace ' || source_to_restore.text;
+    EXCEPTION
+        when OTHERS then
+            if SQLCODE <> -24344 then
+               raise;
+            end if;
+        null;
     end;
 
     -- Functions to generate and clear schema state data

--- a/roles/liquibase/files/nrdk/sql/v2021.11.01.1755.1__create_iitd_lb_support_pkg_body.sql
+++ b/roles/liquibase/files/nrdk/sql/v2021.11.01.1755.1__create_iitd_lb_support_pkg_body.sql
@@ -1,5 +1,5 @@
 --liquibase formatted sql
---changeset qed:iitd_support_pkg_body splitStatements:true endDelimiter:/
+--changeset qed:iitd_support_pkg_body stripComments:false splitStatements:true endDelimiter:/
 --preconditions onFail:WARN onError:HALT onFailMessage:"Running against Oracle RDBMS <= 11"
 --precondition-sql-check expectedResult:STANDARD select decode(min(regexp_replace(regexp_replace(banner,'\..*',''),'.* ','')),'11','LEGACY','STANDARD') from v$version/
 create or replace package body iitd_lb_support_pkg as

--- a/roles/liquibase/files/nrdk/sql/v2021.11.01.1755.1__create_iitd_legacy_lb_support_pkg_body.sql
+++ b/roles/liquibase/files/nrdk/sql/v2021.11.01.1755.1__create_iitd_legacy_lb_support_pkg_body.sql
@@ -125,6 +125,14 @@ create or replace package body iitd_lb_support_pkg as
           and source_name = p_source_name
           and source_version = p_version_number;
         execute immediate 'create or replace ' || source_to_restore.text;
+    EXCEPTION
+        when OTHERS then
+            -- Catch Success with Compilation Error and ignore. When rolling back PL/SQL packages, the body is reverted
+            -- first and if is paired with a Spec change it will fail until the Spec is rolled back too. The recompile
+            -- happens after the rollback.
+            if SQLCODE <> -24344 then
+                raise;
+            end if;
     end;
 
     -- Functions to generate and clear schema state data

--- a/roles/liquibase/files/nrdk/sql/v2021.11.01.1755.1__create_iitd_legacy_lb_support_pkg_body.sql
+++ b/roles/liquibase/files/nrdk/sql/v2021.11.01.1755.1__create_iitd_legacy_lb_support_pkg_body.sql
@@ -1,5 +1,5 @@
 --liquibase formatted sql
---changeset qed:iitd_legacy_support_pkg_body splitStatements:true endDelimiter:/
+--changeset qed:iitd_legacy_support_pkg_body stripComments:false splitStatements:true endDelimiter:/
 --preconditions onFail:CONTINUE onError:HALT
 --precondition-sql-check expectedResult:LEGACY select decode(min(regexp_replace(regexp_replace(banner,'\..*',''),'.* ','')),'11','LEGACY','STANDARD') from v$version/
 create or replace package body iitd_lb_support_pkg as


### PR DESCRIPTION
Patch to ignore compile failure when rolling back PL/SQL change. Body can be temporarily out of date with spec when rolling back, but schema is fully recompiled by framework after rollback is complete.