### PR TITLE
fluentbit version as parameter

### DIFF
--- a/roles/apm_agent/defaults/main.yml
+++ b/roles/apm_agent/defaults/main.yml
@@ -3,9 +3,9 @@ cd_app_service: fluent-bit
 
 apm_agent:
   name: "Fluent Bit"
-  version: "1.7.4"
+  version: "{{ fluentbit_version }}"
   url:
-    zip: "http://bwa.nrs.gov.bc.ca/int/artifactory/ext-binaries-local/fluent/fluent-bit/1.7.4/fluent-bit.tar.gz"
+    zip: "http://bwa.nrs.gov.bc.ca/int/artifactory/ext-binaries-local/fluent/fluent-bit/{{ fluentbit_version }}/fluent-bit.tar.gz"
   service_dir: "/apps_ux/s6_services/fluent-bit"
 
 apm_agent_home: "/apps_ux/agents/main"


### PR DESCRIPTION
Servers might need different versions of fluent bit, so I've made the version a parameter and set it in the host inventory file.