### PR TITLE
added renames to main config

### DIFF
--- a/roles/apm_agent/files/conf/filters.conf
+++ b/roles/apm_agent/files/conf/filters.conf
@@ -6,7 +6,9 @@
     Add ecs.version 1.12.0
     Rename level log.level
     Rename event_sequence event.sequence
+    Rename tomcat_time @timestamp
     Rename message event.original
+    Rename message_parsed message
 
 [FILTER]
     Name lua


### PR DESCRIPTION
We need to rename the message_parsed field to message so we can expose the log messages. I also moved the rename for the tomcat_time field to the main file. This will help simplify the app log configs.