### PR TITLE
add imds ip to no_proxy

### DIFF
--- a/roles/apm_agent/templates/conf/fluent-bit.hcl
+++ b/roles/apm_agent/templates/conf/fluent-bit.hcl
@@ -14,7 +14,7 @@ exec {
   env {
     pristine = false
 {% if fluent_bit_http_proxy is defined %}
-    custom = ["HTTP_PROXY={{ fluent_bit_http_proxy }}","NO_PROXY={{ vault_addr }}"]
+    custom = ["HTTP_PROXY={{ fluent_bit_http_proxy }}","NO_PROXY={{ vault_addr }},169.254.169.254"]
 {% endif %}
   }
 }


### PR DESCRIPTION
We need the IMDS IP added to no_proxy so the latest fluent bit versions work.