### PR TITLE
remove app-specific db directory

### DIFF
--- a/roles/apm_app_collector/tasks/main.yml
+++ b/roles/apm_app_collector/tasks/main.yml
@@ -39,7 +39,6 @@
     - '{{ apm_agent_home }}/conf/{{ app | lower }}-{{ component | lower }}/filter'
     - '{{ apm_agent_home }}/conf/{{ app | lower }}-{{ component | lower }}/input'
     - '{{ apm_agent_home }}/conf/{{ app | lower }}-{{ component | lower }}/parser'
-    - '{{ apm_agent_home }}/db/fluent-bit-logs-{{ app | lower }}-{{ component | lower }}'
   become: yes
   become_user: wwwadm
 

--- a/roles/apm_deploy_collector/files/conf/deploy/input/inputs.conf
+++ b/roles/apm_deploy_collector/files/conf/deploy/input/inputs.conf
@@ -4,7 +4,7 @@
     Path            /apps_ux/logs/jenkins/metrics/deploy*
     Path_Key        log_file_path
     Offset_Key      event_sequence
-    DB              /apps_ux/agents/main/db/fluent-bit-deploy.db
+    DB              /apps_ux/agents/main/db/fluent-bit-logs.db
     Read_from_Head  True
     Key   message
     Mem_Buf_Limit   5MB


### PR DESCRIPTION
We will return to a single db for all logs. Fluent bit isn't handling the multiple db files well.